### PR TITLE
Fix to use episodeId in viewer instead of index

### DIFF
--- a/screens/Root.tsx
+++ b/screens/Root.tsx
@@ -1,5 +1,5 @@
 export type RootStackParamList = {
   Home: undefined;
   Story: { id: string };
-  Viewer: { id: string; index?: number };
+  Viewer: { id: string; episodeId: string };
 };

--- a/screens/Story.tsx
+++ b/screens/Story.tsx
@@ -68,7 +68,7 @@ export function Story() {
           <SectionHeader title="エピソード一覧" style={styles.header} />
         </View>
       )}
-      renderItem={({ item, index }) => {
+      renderItem={({ item }) => {
         // TODO: separate chapter_title
         return (
           <EpisodeItem
@@ -77,7 +77,7 @@ export function Story() {
             onPress={() => {
               navigation.navigate("Viewer", {
                 id: route.params.id,
-                index: item.index,
+                episodeId: item.episodeId,
               });
             }}
           />

--- a/screens/Viewer.tsx
+++ b/screens/Viewer.tsx
@@ -12,13 +12,10 @@ import { ViewerNavigation } from "../components/ViewerNavigation";
 
 type ViewerScreenRouteProp = RouteProp<RootStackParamList, "Viewer">;
 
-function useEpisode(
-  id: string,
-  index: number | undefined
-): BareEpisode | undefined {
+function useEpisode(id: string, episodeId: string): BareEpisode | undefined {
   const [episode, setEpisode] = useState<BareEpisode | undefined>(undefined);
   useEffect(() => {
-    fetchEpisode(id, index?.toString() || "").then((episode) => {
+    fetchEpisode(id, episodeId).then((episode) => {
       // fetchEpisode("n6829bd", "1").then((episode) => { // 普通の
       // fetchEpisode("n1108hj", "1").then((episode) => { // 挿絵付き
       setEpisode(episode);
@@ -33,9 +30,9 @@ type Props = {
 
 export function Viewer(props: Props) {
   const route = useRoute<ViewerScreenRouteProp>();
-  const { id, index } = route.params;
+  const { id, episodeId } = route.params;
   const colors = useColors();
-  const episode = useEpisode(id, index);
+  const episode = useEpisode(id, episodeId);
 
   const [isShowMenu, setIsShowMenu] = useState(false);
   const [pageMax, setPageMax] = useState(1);


### PR DESCRIPTION
I didn't understand anything at posting #9.
An index is just an index. should use episodeId  as seen in https://github.com/rutan/compac-reader/blob/9d90e67949358ba3ecba6bbc43ab5933a94e5b83/src/view/screen/story/index.js#L104-L112