### PR TITLE
Remove SafeArea padding from React Native view

### DIFF
--- a/screens/Viewer.tsx
+++ b/screens/Viewer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, Text, StyleSheet, SafeAreaView } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
 import { RouteProp } from "@react-navigation/native";
 import { RootStackParamList } from "./Root";
 import { useNavigation, useRoute } from "@react-navigation/core";
@@ -77,27 +77,25 @@ export function Viewer(props: Props) {
         maxPage={pageMax}
         onChangePage={(page) => setPage(page)}
       />
-      <SafeAreaView style={styles.container}>
-        <ReaderBrowser
-          body={episode.body}
-          page={page}
-          pageMax={pageMax}
-          pageRate={pageRate}
-          onTap={() => {
-            setIsShowMenu(!isShowMenu);
-          }}
-          onPullPrev={() => {}}
-          onPullNext={() => {}}
-          onUpdatePageMax={(pageMax) => {
-            setPageMax(pageMax);
-          }}
-          onChangePage={(page) => {
-            setPage(page);
-            // TODO: updateBookmark
-            // https://github.com/rutan/compac-reader/blob/9d90e67949358ba3ecba6bbc43ab5933a94e5b83/src/view/screen/reader/index.js#L110-L117
-          }}
-        />
-      </SafeAreaView>
+      <ReaderBrowser
+        body={episode.body}
+        page={page}
+        pageMax={pageMax}
+        pageRate={pageRate}
+        onTap={() => {
+          setIsShowMenu(!isShowMenu);
+        }}
+        onPullPrev={() => {}}
+        onPullNext={() => {}}
+        onUpdatePageMax={(pageMax) => {
+          setPageMax(pageMax);
+        }}
+        onChangePage={(page) => {
+          setPage(page);
+          // TODO: updateBookmark
+          // https://github.com/rutan/compac-reader/blob/9d90e67949358ba3ecba6bbc43ab5933a94e5b83/src/view/screen/reader/index.js#L110-L117
+        }}
+      />
     </View>
   );
 }
@@ -122,5 +120,5 @@ const styles = StyleSheet.create({
     bottom: 0,
     right: 0,
     zIndex: 2,
-  }
+  },
 });


### PR DESCRIPTION

I've added SafeAreaView because of the text on the notch in https://github.com/compac-reader/compac-reader/pull/10#discussion_r775032356
It seems to be fixed in #12, so I removed SafeAreaView from the viewer

|Before|After|
|-|-|
|<img width="561" alt="スクリーンショット 2021-12-27 17 19 17" src="https://user-images.githubusercontent.com/1401711/147451025-ca4ecc24-e1d1-4d8e-824a-ac115917a475.png">|<img width="517" alt="スクリーンショット 2021-12-27 17 18 41" src="https://user-images.githubusercontent.com/1401711/147451030-000c6529-abce-4495-9508-e281e8d9ee2e.png">|
|<img width="520" alt="スクリーンショット 2021-12-27 17 19 19" src="https://user-images.githubusercontent.com/1401711/147451040-a2903943-f893-42f4-8903-e54103d97a4a.png">|<img width="564" alt="スクリーンショット 2021-12-27 17 18 43" src="https://user-images.githubusercontent.com/1401711/147451044-55e00f04-3692-4df3-85c8-54157cc90e7c.png">|

